### PR TITLE
isort on editor save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,10 @@
         "editor.defaultFormatter": "vscode.json-language-features"
     },
     "[python]": {
-        "editor.defaultFormatter": "charliermarsh.ruff"
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.codeActionsOnSave": {
+            "source.organizeImports": "explicit"
+        }
     },
     "[toml]": {
         "editor.defaultFormatter": "tamasfe.even-better-toml"


### PR DESCRIPTION
current problem:

```python
from litellm.types.utils import ModelResponseStream # pyright: ignore[reportMissingTypeStubs]
```

gets reformatted to

```python
from litellm.types.utils import (
    ModelResponseStream,  # pyright: ignore[reportMissingTypeStubs]
)
```

and now I get a pyright error bc the comment needs to be on first line